### PR TITLE
Update repo URLs

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,10 +11,10 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "https://github.com/koszti/sqltools-snowflake-driver.git"
+    "url": "https://github.com/Snowflake-Labs/sqltools-snowflake-driver.git"
   },
   "bugs": {
-    "url": "https://github.com/koszti/sqltools-snowflake-driver/issues",
+    "url": "https://github.com/Snowflake-Labs/sqltools-snowflake-driver/issues",
     "email": "peter.kosztolanyi@gmail.com"
   },
   "scripts": {


### PR DESCRIPTION
This repo moved to snowflake-labs a while ago but the `package.json` is still referencing the old location, hence the extension page on the VSCode marketplace and Open-VSX showing wrong values.